### PR TITLE
Select token when pressing comma

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ Basic typeahead input and results list.
 | clearOnSelection        | `Boolean`              | Clear value after selecting. Primarily used with Tokenizer.                                                                                                                                    |
 | className               | `String`               | String with class name                                                                                                                                                                         |
 | innerRef                | `React reference`      | A `createRef` object                                                                                                                                                                           |
+| separateByComma         | `Boolean`              | Allows you to select an option using a comma.                                                                                                                                                  |
+
 
 ### Tokenizer(props)
 

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@typescript-eslint/parser": "^2.0.0",
     "bootstrap": "^4.1.3",
     "create-react-class": "^15.6.3",
-    "cross-env": "^5.2.0",
+    "cross-env": "^5.2.1",
     "enzyme": "^3.3.0",
     "enzyme-adapter-react-16": "^1.1.1",
     "enzyme-to-json": "^3.4.0",
@@ -88,8 +88,8 @@
     "react-syntax-highlighter": "^11.0.2",
     "react-test-renderer": "^16.9.0",
     "reactstrap": "^8.0.1",
-    "rimraf": "^3.0.0",
-    "rollup": "^1.19.4",
+    "rimraf": "^3.0.2",
+    "rollup": "^1.31.1",
     "rollup-plugin-commonjs": "10.0.2",
     "rollup-plugin-filesize": "6.2.0",
     "rollup-plugin-replace": "2.2.0",
@@ -97,9 +97,10 @@
     "rollup-plugin-terser": "^5.1.1",
     "sinon": "^7.4.1",
     "ts-jest": "^24.0.2",
+    "tsc": "^1.20150623.0",
     "tsc-watch": "2.4.0",
     "tslib": "^1.9.3",
-    "typescript": "^3.5.3"
+    "typescript": "^3.7.5"
   },
   "peerDependencies": {
     "react": ">= 16.8 < 17",

--- a/src/Tokenizer/index.tsx
+++ b/src/Tokenizer/index.tsx
@@ -37,6 +37,7 @@ export interface Props<Opt extends Option>
   onTokenRemove?: (value: Opt) => void;
   onTokenAdd?: (value: Opt) => void;
   renderAbove?: boolean;
+  separateByComma?: boolean;
 }
 
 /**
@@ -74,6 +75,7 @@ const TypeaheadTokenizer = <T extends Option>(props: Props<T>) => {
     searchOptions,
     renderAbove,
     name,
+    separateByComma,
   } = React.useMemo(() => props, [props]);
 
   // Memo section
@@ -172,6 +174,7 @@ const TypeaheadTokenizer = <T extends Option>(props: Props<T>) => {
           onOptionSelected={addTokenForValue}
           onKeyDown={onKeyDown}
           clearOnSelection
+          separateByComma={separateByComma}
         />
       }
       {!renderAbove && (

--- a/src/Typeahead/helpers/useOnKey.ts
+++ b/src/Typeahead/helpers/useOnKey.ts
@@ -18,7 +18,7 @@ interface Props<Opt extends Option>
     > {
   selected: boolean;
   handleOptionSelected: HandleOnOptionSelectArg;
-  customSelectKeys?: string | string[];
+  separateByComma?: boolean;
 }
 
 export default <T extends Option>(props: Props<T>) => {
@@ -34,7 +34,7 @@ export default <T extends Option>(props: Props<T>) => {
     selectionIndex,
     setSelectionIndex,
     setShowOptions,
-    customSelectKeys,
+    separateByComma,
   } = props;
   const { navUp, navDown, clearSelection, selection } = useNav({
     hasHint,
@@ -110,6 +110,10 @@ export default <T extends Option>(props: Props<T>) => {
       events[KeyEvent.DOM_VK_ESCAPE] = clearSelection;
       events[KeyEvent.DOM_VK_TAB] = makeSelection;
 
+      if (separateByComma) {
+        events[KeyEvent.DOM_VK_COMMA] = makeSelection;
+      }
+
       const handler = events[event.keyCode];
       if (handler) {
         handler(event);
@@ -131,6 +135,7 @@ export default <T extends Option>(props: Props<T>) => {
       onKeyDown,
       setShowOptions,
       selected,
+      separateByComma,
     ]
   );
 

--- a/src/Typeahead/helpers/useOnKey.ts
+++ b/src/Typeahead/helpers/useOnKey.ts
@@ -18,6 +18,7 @@ interface Props<Opt extends Option>
     > {
   selected: boolean;
   handleOptionSelected: HandleOnOptionSelectArg;
+  customSelectKeys?: string | string[];
 }
 
 export default <T extends Option>(props: Props<T>) => {
@@ -33,6 +34,7 @@ export default <T extends Option>(props: Props<T>) => {
     selectionIndex,
     setSelectionIndex,
     setShowOptions,
+    customSelectKeys,
   } = props;
   const { navUp, navDown, clearSelection, selection } = useNav({
     hasHint,
@@ -56,7 +58,7 @@ export default <T extends Option>(props: Props<T>) => {
     [onKeyDown, handleOptionSelected, selection]
   );
 
-  const onTab = useCallback(
+  const makeSelection = useCallback(
     (event: React.KeyboardEvent<HTMLInputElement>) => {
       let option: T | undefined =
         selection || filteredOptions.length > 0
@@ -106,7 +108,7 @@ export default <T extends Option>(props: Props<T>) => {
       events[KeyEvent.DOM_VK_RETURN] = onEnter;
       events[KeyEvent.DOM_VK_ENTER] = onEnter;
       events[KeyEvent.DOM_VK_ESCAPE] = clearSelection;
-      events[KeyEvent.DOM_VK_TAB] = onTab;
+      events[KeyEvent.DOM_VK_TAB] = makeSelection;
 
       const handler = events[event.keyCode];
       if (handler) {
@@ -125,7 +127,7 @@ export default <T extends Option>(props: Props<T>) => {
       navDown,
       onEnter,
       clearSelection,
-      onTab,
+      makeSelection,
       onKeyDown,
       setShowOptions,
       selected,

--- a/src/Typeahead/index.tsx
+++ b/src/Typeahead/index.tsx
@@ -54,6 +54,7 @@ export interface Props<Opt extends Option>
   customListComponent?: AnyReactWithProps<Opt>;
   showOptionsWhenEmpty?: boolean;
   innerRef?: React.MutableRefObject<HTMLInputElement | undefined>;
+  separateByComma?: boolean;
 }
 
 /**
@@ -93,6 +94,7 @@ const Typeahead = <T extends Option>(props: Props<T>) => {
     resultsTruncatedMessage,
     showOptionsWhenEmpty,
     name,
+    separateByComma,
   } = React.useMemo(() => props, [props]);
   // The options matching the entry value
 

--- a/src/Typeahead/index.tsx
+++ b/src/Typeahead/index.tsx
@@ -206,6 +206,7 @@ const Typeahead = <T extends Option>(props: Props<T>) => {
     selectionIndex,
     setSelectionIndex,
     setShowOptions,
+    separateByComma,
   });
 
   return (

--- a/src/keyevent.ts
+++ b/src/keyevent.ts
@@ -22,6 +22,6 @@ KeyEvent.DOM_VK_RETURN = KeyEvent.DOM_VK_RETURN || 13;
 KeyEvent.DOM_VK_ENTER = KeyEvent.DOM_VK_ENTER || 14;
 KeyEvent.DOM_VK_ESCAPE = KeyEvent.DOM_VK_ESCAPE || 27;
 KeyEvent.DOM_VK_TAB = KeyEvent.DOM_VK_TAB || 9;
-KeyEvent.DOM_VK_COMMA = KeyEvent.DOM_VK_COMMA || 44;
+KeyEvent.DOM_VK_COMMA = KeyEvent.DOM_VK_COMMA || 188;
 
 export default KeyEvent;

--- a/src/keyevent.ts
+++ b/src/keyevent.ts
@@ -11,6 +11,7 @@ const KeyEvent: {
   DOM_VK_ENTER: number;
   DOM_VK_ESCAPE: number;
   DOM_VK_TAB: number;
+  DOM_VK_COMMA: number;
   // @ts-ignore
 } = KeyEvent || {};
 
@@ -21,5 +22,6 @@ KeyEvent.DOM_VK_RETURN = KeyEvent.DOM_VK_RETURN || 13;
 KeyEvent.DOM_VK_ENTER = KeyEvent.DOM_VK_ENTER || 14;
 KeyEvent.DOM_VK_ESCAPE = KeyEvent.DOM_VK_ESCAPE || 27;
 KeyEvent.DOM_VK_TAB = KeyEvent.DOM_VK_TAB || 9;
+KeyEvent.DOM_VK_COMMA = KeyEvent.DOM_VK_COMMA || 44;
 
 export default KeyEvent;

--- a/test/typeahead/basic.test.tsx
+++ b/test/typeahead/basic.test.tsx
@@ -19,7 +19,7 @@ describe('Typeahead Component basic', () => {
 
   beforeEach(() => {
     testContext.component = mount(
-      <Typeahead options={BEATLES} className="test-class" />
+      <Typeahead options={BEATLES} className="test-class" separateByComma />
     );
   });
 
@@ -106,6 +106,25 @@ describe('Typeahead Component basic', () => {
       results = simulateKeyEvent(results, Keyevent.DOM_VK_TAB);
       expect(getInput(results).prop('value')).toEqual('oz');
     });
+
+    test('when separateByComma = true, comma to choose first item', () => {
+      let results = simulateTextInput(testContext.component, 'o');
+      const first = results
+        .find('ul li')
+        .first()
+        .text();
+
+      results = simulateKeyEvent(results, Keyevent.DOM_VK_COMMA);
+      expect(getInput(results).prop('value')).toEqual(first);
+    });
+
+    test('when separateByComma = true, comma on no selection should not be undefined', () => {
+      let results = simulateTextInput(testContext.component, 'oz');
+      expect(results.find('ul li').length).toEqual(0);
+      results = simulateKeyEvent(results, Keyevent.DOM_VK_COMMA);
+      expect(getInput(results).prop('value')).toEqual('oz');
+    });
+
   });
 
   describe('mouse controls', () => {

--- a/test/typeahead/props.allowCustomValue.test.tsx
+++ b/test/typeahead/props.allowCustomValue.test.tsx
@@ -30,3 +30,28 @@ describe('Typeahead Component props allowCustomValue', () => {
     expect(selectSpy.args[0][0]).toEqual('a');
   });
 });
+
+describe('Typeahead Component props allowCustomValue when separateByComma = true', () => {
+  test('Should display the custom value that can be selected', () => {
+    const sinonBox = sinon.createSandbox();
+    const selectSpy = sinonBox.spy();
+
+    const component = mount(
+      <Typeahead
+        options={BEATLES}
+        allowCustomValues
+        separateByComma
+        onOptionSelected={selectSpy}
+      />
+    );
+
+    simulateTextInput(component, 'a');
+    expect(false).toEqual(selectSpy.called);
+    expect(component.find('li').map(n => n.text())).toEqual(['a', 'Paul']);
+    simulateKeyEvent(component, Keyevent.DOM_VK_COMMA);
+
+    expect(component.find('input[type="text"]').props().value).toEqual('a');
+    expect(true).toEqual(selectSpy.called);
+    expect(selectSpy.args[0][0]).toEqual('a');
+  });
+});


### PR DESCRIPTION
For situations where you would like to create token by separating them via a comma, you can enable the `separateByComma` prop which will enable you to create another token (or fill a typeahead) by using a comma.

This does the same thing as tab but also with a comma.